### PR TITLE
Support Auto Tiling BoxCollider2D

### DIFF
--- a/Runtime/Shapes/Shapes.2D.cs
+++ b/Runtime/Shapes/Shapes.2D.cs
@@ -235,8 +235,21 @@ namespace Vertx.Debugging
 			public Box2D(BoxCollider2D boxCollider)
 			{
 				Transform transform = boxCollider.transform;
-				Matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale * boxCollider.size);
+				Matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale * ColliderLocalSize(boxCollider));
 			}
+#if UNITY_2022_1_OR_NEWER
+			private static Vector2 ColliderLocalSize(BoxCollider2D boxCollider)
+			{
+				if(!boxCollider.autoTiling 
+					|| !boxCollider.TryGetComponent(out SpriteRenderer renderer) 
+					|| renderer.drawMode == SpriteDrawMode.Simple)
+					return boxCollider.size;
+				
+				return renderer.size;
+			}
+#else
+			private static Vector2 ColliderLocalSize(BoxCollider2D boxCollider) => boxCollider.size;
+#endif
 #endif
 
 			[Flags]

--- a/Runtime/Shapes/Shapes.2D.cs
+++ b/Runtime/Shapes/Shapes.2D.cs
@@ -237,7 +237,7 @@ namespace Vertx.Debugging
 				Transform transform = boxCollider.transform;
 				Matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale * ColliderLocalSize(boxCollider));
 			}
-#if UNITY_2022_1_OR_NEWER
+
 			private static Vector2 ColliderLocalSize(BoxCollider2D boxCollider)
 			{
 				if(!boxCollider.autoTiling 
@@ -247,9 +247,7 @@ namespace Vertx.Debugging
 				
 				return renderer.size;
 			}
-#else
-			private static Vector2 ColliderLocalSize(BoxCollider2D boxCollider) => boxCollider.size;
-#endif
+
 #endif
 
 			[Flags]


### PR DESCRIPTION
Added support for `autoTiling` property on BoxCollider2D that will tile the box collider based on the tiling settings for the attached SpriteRenderer, this property does not affect the `size` property which the Box2D class depends on for drawing the correct size gizmo.

![image](https://user-images.githubusercontent.com/2024294/213360975-3196a897-6be3-46e8-895d-aa1a36ff38e7.png)